### PR TITLE
Added pitch, for description in owasp.org/projects

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,6 +5,7 @@ title: OWASP ModSecurity Core Rule Set
 tags: crs
 level: 4
 type: code
+pitch: The OWASP ModSecurity Core Rule Set (CRS) is a set of generic attack detection rules for use with ModSecurity or compatible web application firewalls. The CRS aims to protect web applications from a wide range of attacks, including the OWASP Top Ten, with a minimum of false alerts.
 
 ---
 <!-- build -->


### PR DESCRIPTION
Added a pitch on index.md, so the project gets a description in https://owasp.org/projects/#div-flagships instead of default "More info soon…"